### PR TITLE
Reduce crates.io badge cache duration to 1h

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Utilities for pinning
 
 [![Build Status](https://travis-ci.org/rust-lang-nursery/pin-utils.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/pin-utils)
-[![Crates.io](https://img.shields.io/crates/v/pin-utils.svg?maxAge=2592000)](https://crates.io/crates/pin-utils)
+[![Crates.io](https://img.shields.io/crates/v/pin-utils.svg)](https://crates.io/crates/pin-utils)
 
 [Documentation](https://docs.rs/pin-utils)
 


### PR DESCRIPTION
This changes the max age from 30days to 1h