### PR TITLE
Use new path for importing PinMut

### DIFF
--- a/src/projection.rs
+++ b/src/projection.rs
@@ -9,8 +9,8 @@
 /// ```
 /// # #![feature(pin, arbitrary_self_types)]
 /// # #[macro_use] extern crate pin_utils;
-/// # use std::mem::PinMut;
 /// # use std::marker::Unpin;
+/// # use std::pin::PinMut;
 /// struct Foo<T> {
 ///     field: T,
 /// }
@@ -32,10 +32,10 @@
 macro_rules! unsafe_pinned {
     ($f:tt: $t:ty) => (
         fn $f<'__a>(
-            self: &'__a mut $crate::core_reexport::mem::PinMut<Self>
-        ) -> $crate::core_reexport::mem::PinMut<'__a, $t> {
+            self: &'__a mut $crate::core_reexport::pin::PinMut<Self>
+        ) -> $crate::core_reexport::pin::PinMut<'__a, $t> {
             unsafe {
-                $crate::core_reexport::mem::PinMut::map_unchecked(
+                $crate::core_reexport::pin::PinMut::map_unchecked(
                     self.reborrow(), |x| &mut x.$f
                 )
             }
@@ -53,7 +53,7 @@ macro_rules! unsafe_pinned {
 /// ```
 /// # #![feature(pin, arbitrary_self_types)]
 /// # #[macro_use] extern crate pin_utils;
-/// # use std::mem::PinMut;
+/// # use std::pin::PinMut;
 /// # struct Bar;
 /// struct Foo {
 ///     field: Bar,
@@ -71,10 +71,10 @@ macro_rules! unsafe_pinned {
 macro_rules! unsafe_unpinned {
     ($f:tt: $t:ty) => (
         fn $f<'__a>(
-            self: &'__a mut $crate::core_reexport::mem::PinMut<Self>
+            self: &'__a mut $crate::core_reexport::pin::PinMut<Self>
         ) -> &'__a mut $t {
             unsafe {
-                &mut $crate::core_reexport::mem::PinMut::get_mut_unchecked(
+                &mut $crate::core_reexport::pin::PinMut::get_mut_unchecked(
                     self.reborrow()
                 ).$f
             }

--- a/src/stack_pin.rs
+++ b/src/stack_pin.rs
@@ -3,7 +3,7 @@
 /// ```
 /// # #![feature(pin)]
 /// # #[macro_use] extern crate pin_utils;
-/// # use core::mem::PinMut;
+/// # use core::pin::PinMut;
 /// # struct Foo {}
 /// let foo = Foo { /* ... */ };
 /// pin_mut!(foo);
@@ -18,7 +18,7 @@ macro_rules! pin_mut {
         // ever again.
         #[allow(unused_mut)]
         let mut $x = unsafe {
-            $crate::core_reexport::mem::PinMut::new_unchecked(&mut $x)
+            $crate::core_reexport::pin::PinMut::new_unchecked(&mut $x)
         };
     )* }
 }

--- a/tests/projection.rs
+++ b/tests/projection.rs
@@ -1,7 +1,7 @@
 #![feature(pin, arbitrary_self_types)]
 #[macro_use] extern crate pin_utils;
-use std::mem::PinMut;
 use std::marker::Unpin;
+use std::pin::PinMut;
 
 struct Foo<T1, T2> {
     field1: T1,

--- a/tests/stack_pin.rs
+++ b/tests/stack_pin.rs
@@ -1,6 +1,6 @@
 #![feature(pin)]
 #[macro_use] extern crate pin_utils;
-use core::mem::PinMut;
+use core::pin::PinMut;
 
 #[test]
 fn stack_pin() {


### PR DESCRIPTION
Ref: https://github.com/rust-lang/rust/pull/53227

Fixes #4

---

All tests of this crate pass, and futures-rs's compiles and its tests pass. I didn't try anything else.

Travis fails because the latest nightly doesn't have clippy. I built clippy's master locally and `cargo clippy` has no failures.