### PR TITLE
Don't run clippy if it's not currently available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,13 @@ matrix:
 
     - name: cargo clippy
       rust: nightly
-      install:
-        - rustup component add clippy-preview
       script:
-        - cargo clippy -- -Dwarnings
+        - if rustup component add clippy-preview;
+          then
+            cargo clippy -- -Dwarnings;
+          else
+            echo 'Skipping clippy';
+          fi
 
     - name: cargo doc
       rust: nightly


### PR DESCRIPTION
Fixes #6 

Unfortunately just using a dated nightly for clippy won't work. As an example `nightly-2018-08-28` does include a working clippy, but having the clippy build use that would still cause #3 to fail as the new code will no longer compile with `nightly-2018-08-28`.

Best solution I can find for this sort of bleeding edge development is to just not run clippy when the nightly doesn't include it, once stuff gets closer to stabilisation then using a pinned nightly might be more doable. This can mean that latent errors that will fail clippy later can make it into master, but those can just be fixed as they happen.