### PR TITLE
Add the minimum required version to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
     - name: cargo test
       os: linux
 
+    # When updating this, the reminder to update the minimum required version in README.md.
+    - name: cargo test (minimum required version)
+      rust: nightly-2018-12-26
+
     - name: cargo clippy
       rust: nightly
       script:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Now, you can use it:
 use pin_utils::pin_mut; // And more...
 ```
 
+The current version of pin-utils requires Rust nightly 2018-12-26 or later.
+
 # License
 
 This project is licensed under either of


### PR DESCRIPTION
I think that it is preferable to display the minimum required version.

Related: #17