### PR TITLE
Support trailing commas in pin_mut! macro

### DIFF
--- a/src/stack_pin.rs
+++ b/src/stack_pin.rs
@@ -10,7 +10,7 @@
 /// ```
 #[macro_export]
 macro_rules! pin_mut {
-    ($($x:ident),*) => { $(
+    ($($x:ident),* $(,)?) => { $(
         // Move the value to ensure that it is owned
         let mut $x = $x;
         // Shadow the original binding so that it can't be directly accessed

--- a/tests/stack_pin.rs
+++ b/tests/stack_pin.rs
@@ -7,4 +7,13 @@ fn stack_pin() {
     let foo = Foo {};
     pin_mut!(foo);
     let _: Pin<&mut Foo> = foo;
+
+    let bar = Foo {};
+    let baz = Foo {};
+    pin_mut!(
+        bar,
+        baz,
+    );
+    let _: Pin<&mut Foo> = bar;
+    let _: Pin<&mut Foo> = baz;
 }


### PR DESCRIPTION
I think it makes sense to support this because `pin_mut` can take multiple arguments.

Related: https://github.com/rust-lang/rust/pull/48056, https://github.com/rust-lang-nursery/futures-rs/pull/1733