### PR TITLE
Add #[allow(unsafe_code)] to projection macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,10 @@ matrix:
       os: linux
 
     - name: cargo clippy
-      rust: nightly
+      rust: stable
       script:
-        - if rustup component add clippy-preview;
-          then
-            cargo clippy -- -Dwarnings;
-          else
-            echo 'Skipping clippy';
-          fi
+        - rustup component add clippy
+        - cargo clippy -- -Dwarnings
 
     - name: cargo doc
       rust: nightly

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -35,6 +35,7 @@
 #[macro_export]
 macro_rules! unsafe_pinned {
     ($f:tt: $t:ty) => (
+        #[allow(unsafe_code)]
         fn $f<'__a>(
             self: $crate::core_reexport::pin::Pin<&'__a mut Self>
         ) -> $crate::core_reexport::pin::Pin<&'__a mut $t> {
@@ -77,6 +78,7 @@ macro_rules! unsafe_pinned {
 #[macro_export]
 macro_rules! unsafe_unpinned {
     ($f:tt: $t:ty) => (
+        #[allow(unsafe_code)]
         fn $f<'__a>(
             self: $crate::core_reexport::pin::Pin<&'__a mut Self>
         ) -> &'__a mut $t {

--- a/tests/stack_pin.rs
+++ b/tests/stack_pin.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)] // pin_mut! is completely safe.
+
 use pin_utils::pin_mut;
 use core::pin::Pin;
 


### PR DESCRIPTION
I feel the current behavior of lint is a little odd, but I'd like to prevent unsafe macros from being used on the crate that forbids unsafe_code.

This may break some crate, but pin-utils is still alpha, so should be acceptable.

Closes #2

r? @cramertj 
cc @Nemo157 