### PR TITLE
Deprecate unsafe pin projection macros

### DIFF
--- a/src/projection.rs
+++ b/src/projection.rs
@@ -36,6 +36,10 @@
 ///
 /// [`Unpin`]: core::marker::Unpin
 /// [`drop`]: Drop::drop
+#[deprecated(
+    since = "0.1.1",
+    note = "this macro is not safe; use pin-project or pin-project-lite crate instead"
+)]
 #[macro_export]
 macro_rules! unsafe_pinned {
     ($f:tt: $t:ty) => {
@@ -81,6 +85,10 @@ macro_rules! unsafe_pinned {
 /// avoid consuming the [`Pin`].
 ///
 /// [`Pin`]: core::pin::Pin
+#[deprecated(
+    since = "0.1.1",
+    note = "this macro is not safe; use pin-project or pin-project-lite crate instead"
+)]
 #[macro_export]
 macro_rules! unsafe_unpinned {
     ($f:tt: $t:ty) => {

--- a/tests/projection.rs
+++ b/tests/projection.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use pin_utils::{pin_mut, unsafe_pinned, unsafe_unpinned};
 use std::marker::Unpin;
 use std::pin::Pin;


### PR DESCRIPTION
Use of these macros in futures-rs has been removed, so we can probably go ahead this.

Closes #29

r? @cramertj @Nemo157 