### PR TITLE
Docs: document why pin_mut! is useful

### DIFF
--- a/src/stack_pin.rs
+++ b/src/stack_pin.rs
@@ -1,5 +1,7 @@
 /// Pins a value on the stack.
 ///
+/// Can safely pin values that are not `Unpin` by taking ownership.
+///
 /// # Example
 ///
 /// ```rust


### PR DESCRIPTION
I'm new to Rust, and came across `pin_mut!` via references from other crates like `async_stream`.

It wasn't immediately clear to me why I'd use `pin_mut!` instead of something from the standard library, like `std::pin::Pin::new`, until I ran into some trouble pinning a struct that was not `Unpin`.  Since `pin_mut!` makes this trivial, it might be helpful to other new folks to clearly state this advantage in the docstring.