### PR TITLE
Make pin_mut! soft-deprecated in favor of std::pin::pin!

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Utilities for pinning
 
 [Documentation][docs-url]
 
+**Note:** Since Rust 1.68, all APIs in this crate are now soft-deprecated or deprecated:
+
+- `pin_utils::pin_mut!` is soft-deprecated in favor of [`pin!` macro in the standard library](https://doc.rust-lang.org/std/pin/macro.pin.html) that stabilized in Rust 1.68.
+- `pin_utils::{unsafe_pinned,unsafe_unpinned}` are **deprecated** in favor of safe alternatives: [pin-project](https://crates.io/crates/pin-project), [pin-project-lite](https://crates.io/crates/pin-project-lite)
+
 ## Usage
 
 First, add this to your `Cargo.toml`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
 //! Utilities for pinning
+//!
+//! **Note:** Since Rust 1.68, all APIs in this crate are now soft-deprecated or deprecated:
+//!
+//! - `pin_utils::pin_mut!` is soft-deprecated in favor of [`pin!` macro in the standard library](https://doc.rust-lang.org/std/pin/macro.pin.html) that stabilized in Rust 1.68.
+//! - `pin_utils::{unsafe_pinned,unsafe_unpinned}` are **deprecated** in favor of safe alternatives: [pin-project](https://crates.io/crates/pin-project), [pin-project-lite](https://crates.io/crates/pin-project-lite)
 
 #![no_std]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -38,7 +38,7 @@
 /// [`drop`]: Drop::drop
 #[deprecated(
     since = "0.1.1",
-    note = "this macro is not safe; use pin-project or pin-project-lite crate instead"
+    note = "this macro is not safe; use safe pin-project or pin-project-lite crate instead"
 )]
 #[macro_export]
 macro_rules! unsafe_pinned {
@@ -87,7 +87,7 @@ macro_rules! unsafe_pinned {
 /// [`Pin`]: core::pin::Pin
 #[deprecated(
     since = "0.1.1",
-    note = "this macro is not safe; use pin-project or pin-project-lite crate instead"
+    note = "this macro is not safe; use safe pin-project or pin-project-lite crate instead"
 )]
 #[macro_export]
 macro_rules! unsafe_unpinned {

--- a/src/stack_pin.rs
+++ b/src/stack_pin.rs
@@ -2,6 +2,9 @@
 ///
 /// Can safely pin values that are not `Unpin` by taking ownership.
 ///
+/// **Note:** Since Rust 1.68, this macro is soft-deprecated in favor of
+/// [`pin!`](core::pin::pin) macro in the standard library.
+///
 /// # Example
 ///
 /// ```rust


### PR DESCRIPTION
This makes `pin_mut!` macro soft-deprecated in favor of `std::pin::pin!` that stabilized in Rust 1.68.

Since `pin_mut!` is still useful for pre-1.68 Rust users, this is a soft deprecation rather than a normal deprecation (`#[deprecated]`).

Combining this and the deprecation of other macros in https://github.com/rust-lang/pin-utils/pull/33, all APIs in this crate are now soft-deprecated or deprecated, so I updated readme and docs to add the following note:

> **Note:** Since Rust 1.68, all APIs in this crate are now soft-deprecated or deprecated:
> 
> - `pin_utils::pin_mut!` is soft-deprecated in favor of [`pin!` macro in the standard library](https://doc.rust-lang.org/std/pin/macro.pin.html) that stabilized in Rust 1.68.
> - `pin_utils::{unsafe_pinned,unsafe_unpinned}` are **deprecated** in favor of safe alternatives: [pin-project](https://crates.io/crates/pin-project), [pin-project-lite](https://crates.io/crates/pin-project-lite)